### PR TITLE
fix: github actions (adds missing npm scripts)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build_and_test:
     uses: homebridge/.github/.github/workflows/nodejs-build-and-test.yml@main
     with:
-      enable_coverage: true
+      enable_coverage: false
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
   lint:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   "scripts": {
     "lint": "eslint src/**.ts --max-warnings=0",
     "build": "rimraf ./dist && tsc --project tsconfig.json && tsc --project tsconfig.ui.json",
-    "prepublishOnly": "npm run lint && npm run build"
+    "prepublishOnly": "npm run lint && npm run build",
+    "test": "echo \"No test script specified\" && exit 0",
+    "test-coverage": "echo \"No test-coverage script specified\" && exit 0"
   },
   "devDependencies": {
     "@types/node": "^20.6.3",


### PR DESCRIPTION
GItHub actions are failing because the `test` and `test-coverage` scripts do not exist in the package.json file. This repo does not use jest for testing, or anything like this.

There were some options here, to remove this section from the actions file, to add blank npm scripts to the package json file, etc.

I went for this method, to try and keep all the action files similar between different homebridge repos.