### PR TITLE
Resolve failed link requests

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -123,6 +123,7 @@ class HomebridgePluginUi extends EventTargetConstructor {
       linkElement.setAttribute('href', e.data.href);
       linkElement.setAttribute('rel', e.data.rel);
       linkElement.onload = resolve;
+      linkElement.onerror = resolve;
       document.head.appendChild(linkElement);
     });
     this.linkRequests.push(request);


### PR DESCRIPTION
## :recycle: Current situation

Some plug-ins are not displaying any body modal content for some users. This is likely attributed to failed network requests.

## :bulb: Proposed solution

Add an `onerror` attribute to the link elements and resolve the waiting promise.

Adding a call to `setTimeout` might also be needed in the future if network requests are failing too slowly.

This should fix https://github.com/homebridge/homebridge-config-ui-x/issues/1527.