### PR TITLE
fix: package.json not export ui.interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,17 @@
     "homebridge",
     "homebridge-ui"
   ],
-  "exports": "./dist/index.js",
+  "exports": {
+    ".": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./ui.interface": {
+      "default": "./dist/ui.interface.js",
+      "types": "./dist/ui.interface.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "types": "dist/index.d.ts",
   "files": [
     "LICENSE",


### PR DESCRIPTION
This pull request includes updates to the `package.json` file to improve module exports and type definitions.

Key changes:

* Modified the `exports` field to provide separate entries for default and type exports for both the main module and the `ui.interface` module.