### PR TITLE
chore: expose HomebridgeUi types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { HomebridgePluginUiServer, RequestError } from './server.js'
-export type { IHomebridgePluginUi, IHomebridgeUiFormHelper, IHomebridgeUiToastHelper } from "./ui.interface.js"
+export type { IHomebridgePluginUi, IHomebridgeUiFormHelper, IHomebridgeUiToastHelper } from './ui.interface.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { HomebridgePluginUiServer, RequestError } from './server.js'
+export type { IHomebridgePluginUi, IHomebridgeUiFormHelper, IHomebridgeUiToastHelper } from "./ui.interface.js"


### PR DESCRIPTION
Expose the `IHomebridgeUi...` types to access them in plugins using custom UI.

I'm planning to write the custom UI script part in TypeScript and then compile it to js. For this, it would be nice to have these types available. 

The other types can be exposed as well, if you think it's needed or it's better that way.